### PR TITLE
Fix caddy imports

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/asaskevich/govalidator"
-	"github.com/mholt/caddy/caddyfile"
+	"github.com/caddyserver/caddy/caddyfile"
 )
 
 type config struct {

--- a/config_test.go
+++ b/config_test.go
@@ -1,9 +1,12 @@
 package ipecho
 
-import "testing"
-import "github.com/mholt/caddy/caddyfile"
-import "github.com/tdewolff/buffer"
-import "github.com/stretchr/testify/require"
+import (
+	"testing"
+
+	"github.com/caddyserver/caddy/caddyfile"
+	"github.com/stretchr/testify/require"
+	"github.com/tdewolff/buffer"
+)
 
 func TestNewConfigFromDispenser(t *testing.T) {
 	t.Run("Valid Config", func(t *testing.T) {

--- a/setup.go
+++ b/setup.go
@@ -4,7 +4,7 @@ import (
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 )
 
 func init() {


### PR DESCRIPTION
Hi there!

The caddy repository moved from `github.com/mholt/caddy` to `github.com/caddyserver/caddy`. This MR fixes all the caddy imports.

Thanks
Nick