### PR TITLE
Fix caddy import

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/asaskevich/govalidator"
-	"github.com/caddyserver/caddy/caddyfile"
+	"github.com/coredns/caddy/caddyfile"
 )
 
 type config struct {

--- a/config_test.go
+++ b/config_test.go
@@ -3,7 +3,7 @@ package ipecho
 import (
 	"testing"
 
-	"github.com/caddyserver/caddy/caddyfile"
+	"github.com/coredns/caddy/caddyfile"
 	"github.com/stretchr/testify/require"
 	"github.com/tdewolff/buffer"
 )

--- a/setup.go
+++ b/setup.go
@@ -4,7 +4,7 @@ import (
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 
-	"github.com/caddyserver/caddy"
+	"github.com/coredns/caddy"
 )
 
 func init() {


### PR DESCRIPTION
Hi,
caddy repository it's internalized by CoreDNS. This MR fixes all caddy imports.

From CoreDNS Release Note 1.8.0:
... because Caddy is now developing a version 2 and we are using version 1, we've internalized
Caddy into <https://github.com/coredns/caddy>. This means the `caddy` types change and *all* plugins
need to fix the import path from: `github.com/caddyserver/caddy` to
`github.com/coredns/caddy` ...

Thanks,
Edoardo.